### PR TITLE
URL Cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,9 +6,9 @@ Maintainer: Gaurav Sood <gsood07@gmail.com>
 Description: Use VirusTotal, a Google service that analyzes files and URLs 
     for viruses, worms, trojans etc., provides category of the content hosted by a 
     domain from a variety of prominent services, provides passive DNS information,
-    among other things. See <http://www.virustotal.com> for more information. 
-URL: http://github.com/soodoku/virustotal
-BugReports: http://github.com/soodoku/virustotal/issues
+    among other things. See <https://www.virustotal.com> for more information. 
+URL: https://github.com/soodoku/virustotal
+BugReports: https://github.com/soodoku/virustotal/issues
 Depends:
     R (>= 3.3.0)
 License: MIT + file LICENSE

--- a/R/domain_report.R
+++ b/R/domain_report.R
@@ -23,8 +23,8 @@
 #' 
 #' # Before calling the function, set the API key using set_key('api_key_here')
 #'    
-#' domain_report("http://www.google.com")
-#' domain_report("http://www.goodsfwrfw.com") # Domain not found
+#' domain_report("https://www.google.com")
+#' domain_report("https://www.goodsfwrfw.com") # Domain not found
 #' }
 
 domain_report <- function(domain = NULL, ...) {

--- a/R/scan_url.R
+++ b/R/scan_url.R
@@ -19,7 +19,7 @@
 #' 
 #' # Before calling the function, set the API key using set_key('api_key_here')
 #' 
-#' scan_url("http://www.google.com")
+#' scan_url("https://www.google.com")
 #' }
 
 scan_url <- function(url = NULL, ...) {

--- a/R/url_report.R
+++ b/R/url_report.R
@@ -22,7 +22,7 @@
 #' 
 #' # Before calling the function, set the API key using set_key('api_key_here')
 #' 
-#' url_report("http://www.google.com")
+#' url_report("https://www.google.com")
 #' url_report(scan_id = "ebdd15c397d2b0c6f50c3f2df531357d1201ff5976802316405e60880d6bf5ec-1478786749")
 #' }
 

--- a/R/virustotal.R
+++ b/R/virustotal.R
@@ -39,7 +39,7 @@ function(query=list(), path = path, key = Sys.getenv("VirustotalToken"), ...) {
 
 	rate_limit()
 
-	res <- GET("http://www.virustotal.com/", path = paste0("vtapi/v2/", path), query = query, ...)
+	res <- GET("https://www.virustotal.com/", path = paste0("vtapi/v2/", path), query = query, ...)
 	virustotal_check(res)
 	res <- content(res)
 
@@ -67,7 +67,7 @@ function(query=list(), path = path, body=NULL, key = Sys.getenv("VirustotalToken
 
 	rate_limit()
 
-	res <- POST("http://www.virustotal.com/", path = paste0("vtapi/v2/", path), query = query, body = body, ...)
+	res <- POST("https://www.virustotal.com/", path = paste0("vtapi/v2/", path), query = query, body = body, ...)
 	virustotal_check(res)
 	res <- content(res)
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/soodoku/virustotal.svg?branch=master)](https://travis-ci.org/soodoku/virustotal)
 [![Build status](https://ci.appveyor.com/api/projects/status/pvqoje98iq6dee3q?svg=true)](https://ci.appveyor.com/project/soodoku/virustotal)
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/virustotal)](https://cran.r-project.org/package=virustotal)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/virustotal)](https://cran.r-project.org/package=virustotal)
 ![](https://cranlogs.r-pkg.org/badges/grand-total/virustotal)
 [![codecov](https://codecov.io/gh/soodoku/virustotal/branch/master/graph/badge.svg)](https://codecov.io/gh/soodoku/virustotal)
 
-Use [VirusTotal](http://www.virustotal.com), a Google service that analyzes files and URLs for viruses, worms, trojans etc., provides category of the content hosted by a domain from a variety of prominent services, provides passive DNS information, among other things. 
+Use [VirusTotal](https://www.virustotal.com), a Google service that analyzes files and URLs for viruses, worms, trojans etc., provides category of the content hosted by a domain from a variety of prominent services, provides passive DNS information, among other things. 
 
 As of June, 2016, Public API 2.0 had the following rate limits:
 
@@ -16,7 +16,7 @@ As of June, 2016, Public API 2.0 had the following rate limits:
 | Day           | 5760 requests/day     |
 | Month         | 178560 requests/month |
 
-See [http://www.virustotal.com](http://www.virustotal.com) for more information. 
+See [https://www.virustotal.com](https://www.virustotal.com) for more information. 
 
 ### Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 init:
   ps: |
         $ErrorActionPreference = "Stop"
-        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Invoke-WebRequest https://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 install:
   ps: Bootstrap

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -97,7 +97,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/articles/using_virustotal.html
+++ b/docs/articles/using_virustotal.html
@@ -25,7 +25,7 @@
   <a href="../news/index.html">News</a>
 </li>
       </ul><ul class="nav navbar-nav navbar-right"><li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -66,31 +66,31 @@
 <div id="get-domain-report" class="section level4">
 <h4 class="hasAnchor"><html><body><a href="#get-domain-report" class="anchor"> </a></body></html>Get domain report</h4>
 <p>Get report on a domain, including passive DNS:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/domain_report.html">domain_report</a></span>(<span class="st">"http://www.google.com"</span>)$categories</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/domain_report.html">domain_report</a></span>(<span class="st">"https://www.google.com"</span>)$categories</code></pre></div>
 <pre><code>## [[1]]
 ## [1] "searchengines"</code></pre>
 </div>
 <div id="scan-url" class="section level4">
 <h4 class="hasAnchor"><html><body><a href="#scan-url" class="anchor"> </a></body></html>Scan URL</h4>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/scan_url.html">scan_url</a></span>(<span class="st">"http://www.google.com"</span>)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/scan_url.html">scan_url</a></span>(<span class="st">"https://www.google.com"</span>)</code></pre></div>
 <pre><code>##                                                                                                             permalink               resource
-## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ http://www.google.com/</code></pre>
+## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ https://www.google.com/</code></pre>
 </div>
 <div id="get-url-report" class="section level4">
 <h4 class="hasAnchor"><html><body><a href="#get-url-report" class="anchor"> </a></body></html>Get URL report</h4>
 <p>Get report on a domain, including URL:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">head</span>(<span class="kw"><a href="../reference/url_report.html">url_report</a></span>(<span class="st">"http://www.google.com"</span>)[, <span class="dv">1</span>:<span class="dv">2</span>], <span class="dv">10</span>)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">head</span>(<span class="kw"><a href="../reference/url_report.html">url_report</a></span>(<span class="st">"https://www.google.com"</span>)[, <span class="dv">1</span>:<span class="dv">2</span>], <span class="dv">10</span>)</code></pre></div>
 <pre><code>##                                                                        scan_id              resource
-## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com</code></pre>
+## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com</code></pre>
 </div>
 <div id="get-ip-report" class="section level4">
 <h4 class="hasAnchor"><html><body><a href="#get-ip-report" class="anchor"> </a></body></html>Get IP report</h4>
@@ -144,7 +144,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer></div>

--- a/docs/articles/using_virustotal.md
+++ b/docs/articles/using_virustotal.md
@@ -42,7 +42,7 @@ Get report on a domain, including passive DNS:
 
 
 ```r
-domain_report("http://www.google.com")$categories
+domain_report("https://www.google.com")$categories
 ```
 ```
 ## [[1]]
@@ -52,12 +52,12 @@ domain_report("http://www.google.com")$categories
 
 
 ```r
-scan_url("http://www.google.com")
+scan_url("https://www.google.com")
 ```
 
 ```
 ##                                                                                                             permalink               resource
-## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ http://www.google.com/
+## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ https://www.google.com/
 ```
 
 #### Get URL report
@@ -66,20 +66,20 @@ Get report on a domain, including URL:
 
 
 ```r
-head(url_report("http://www.google.com")[, 1:2], 10)
+head(url_report("https://www.google.com")[, 1:2], 10)
 ```
 ```
 ##                                                                        scan_id              resource
-## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
+## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
 ```
 #### Get IP report
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -98,7 +98,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -79,8 +79,8 @@
     <div id="virustotal-r-client-for-the-virustotal-public-api-2-0" class="section level2">
 <h2 class="hasAnchor">
 <html><a href="#virustotal-r-client-for-the-virustotal-public-api-2-0" class="anchor"> </a></html>virustotal: R Client for the VirusTotal Public API 2.0</h2>
-<p><a href="https://travis-ci.org/soodoku/virustotal"><img src="https://travis-ci.org/soodoku/virustotal.svg?branch=master" alt="Build Status"></a> <a href="https://ci.appveyor.com/project/soodoku/virustotal"><img src="https://ci.appveyor.com/api/projects/status/pvqoje98iq6dee3q?svg=true" alt="Build status"></a> <a href="https://cran.r-project.org/package=virustotal"><img src="http://www.r-pkg.org/badges/version/virustotal" alt="CRAN_Status_Badge"></a> <img src="https://cranlogs.r-pkg.org/badges/grand-total/virustotal"><a href="https://codecov.io/gh/soodoku/virustotal"><img src="https://codecov.io/gh/soodoku/virustotal/branch/master/graph/badge.svg" alt="codecov"></a></p>
-<p>Use <a href="http://www.virustotal.com">VirusTotal</a>, a Google service that analyzes files and URLs for viruses, worms, trojans etc., provides category of the content hosted by a domain from a variety of prominent services, provides passive DNS information, among other things.</p>
+<p><a href="https://travis-ci.org/soodoku/virustotal"><img src="https://travis-ci.org/soodoku/virustotal.svg?branch=master" alt="Build Status"></a> <a href="https://ci.appveyor.com/project/soodoku/virustotal"><img src="https://ci.appveyor.com/api/projects/status/pvqoje98iq6dee3q?svg=true" alt="Build status"></a> <a href="https://cran.r-project.org/package=virustotal"><img src="https://www.r-pkg.org/badges/version/virustotal" alt="CRAN_Status_Badge"></a> <img src="https://cranlogs.r-pkg.org/badges/grand-total/virustotal"><a href="https://codecov.io/gh/soodoku/virustotal"><img src="https://codecov.io/gh/soodoku/virustotal/branch/master/graph/badge.svg" alt="codecov"></a></p>
+<p>Use <a href="https://www.virustotal.com">VirusTotal</a>, a Google service that analyzes files and URLs for viruses, worms, trojans etc., provides category of the content hosted by a domain from a variety of prominent services, provides passive DNS information, among other things.</p>
 <p>As of June, 2016, Public API 2.0 had the following rate limits:</p>
 <table>
 <thead><tr class="header">
@@ -102,7 +102,7 @@
 </tr>
 </tbody>
 </table>
-<p>See <a href="http://www.virustotal.com" class="uri">http://www.virustotal.com</a> for more information.</p>
+<p>See <a href="https://www.virustotal.com" class="uri">https://www.virustotal.com</a> for more information.</p>
 <div id="installation" class="section level3">
 <h3 class="hasAnchor">
 <html><a href="#installation" class="anchor"> </a></html>Installation</h3>
@@ -130,8 +130,8 @@ devtools::<span class="kw">install_github</span>(<span class="st">"soodoku/virus
   <div class="col-md-3" id="sidebar">
     <h2>Links</h2><ul class='list-unstyled'>
 <li>Download from CRAN at <br /><a href='https://cran.r-project.org/package=virustotal'>https://&#8203;cran.r-project.org/&#8203;package=virustotal</a></li>
-<li>Browse source code at <br /><a href='http://github.com/soodoku/virustotal'>http://&#8203;github.com/&#8203;soodoku/&#8203;virustotal</a></li>
-<li>Report a bug at <br /><a href='http://github.com/soodoku/virustotal/issues'>http://&#8203;github.com/&#8203;soodoku/&#8203;virustotal/&#8203;issues</a></li>
+<li>Browse source code at <br /><a href='https://github.com/soodoku/virustotal'>https://&#8203;github.com/&#8203;soodoku/&#8203;virustotal</a></li>
+<li>Report a bug at <br /><a href='https://github.com/soodoku/virustotal/issues'>https://&#8203;github.com/&#8203;soodoku/&#8203;virustotal/&#8203;issues</a></li>
 </ul>
 <h2>License</h2>
 <p><a href='https://opensource.org/licenses/mit-license.php'>MIT</a> + file <a href='LICENSE'>LICENSE</a></p>
@@ -150,7 +150,7 @@ devtools::<span class="kw">install_github</span>(<span class="st">"soodoku/virus
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/jquery.sticky-kit.min.js
+++ b/docs/jquery.sticky-kit.min.js
@@ -1,5 +1,5 @@
 /*
- Sticky-kit v1.1.2 | WTFPL | Leaf Corcoran 2015 | http://leafo.net
+ Sticky-kit v1.1.2 | WTFPL | Leaf Corcoran 2015 | https://leafo.net
 */
 (function(){var b,f;b=this.jQuery||window.jQuery;f=b(window);b.fn.stick_in_parent=function(d){var A,w,J,n,B,K,p,q,k,E,t;null==d&&(d={});t=d.sticky_class;B=d.inner_scrolling;E=d.recalc_every;k=d.parent;q=d.offset_top;p=d.spacer;w=d.bottoming;null==q&&(q=0);null==k&&(k=void 0);null==B&&(B=!0);null==t&&(t="is_stuck");A=b(document);null==w&&(w=!0);J=function(a,d,n,C,F,u,r,G){var v,H,m,D,I,c,g,x,y,z,h,l;if(!a.data("sticky_kit")){a.data("sticky_kit",!0);I=A.height();g=a.parent();null!=k&&(g=g.closest(k));
 if(!g.length)throw"failed to find stick parent";v=m=!1;(h=null!=p?p&&a.closest(p):b("<div />"))&&h.css("position",a.css("position"));x=function(){var c,f,e;if(!G&&(I=A.height(),c=parseInt(g.css("border-top-width"),10),f=parseInt(g.css("padding-top"),10),d=parseInt(g.css("padding-bottom"),10),n=g.offset().top+c+f,C=g.height(),m&&(v=m=!1,null==p&&(a.insertAfter(h),h.detach()),a.css({position:"",top:"",width:"",bottom:""}).removeClass(t),e=!0),F=a.offset().top-(parseInt(a.css("margin-top"),10)||0)-q,

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -91,9 +91,9 @@
 <li>url_report now accepts scan_id as a param</li>
 <li>Warning messages end with new line</li>
 <li>Added more tests, specifically checking returns to what happens when params/hash are incorrect<br/></li>
-<li>Enforces rate limiting — 4 queries per minute.</li>
+<li>Enforces rate limiting ï¿½ 4 queries per minute.</li>
 <li>Graceful error handling if error limit exceeded.</li>
-<li>changed virustotal to VirusTotal as CRAN doesn’t muck around.</li>
+<li>changed virustotal to VirusTotal as CRAN doesnï¿½t muck around.</li>
 </ul></div>
     <div id="virustotal-0-1-0" class="section level1">
 <h1 class="hasAnchor">
@@ -121,7 +121,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/add_comments.html
+++ b/docs/reference/add_comments.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Add comments on Files and URLs � add_comments • virustotal</title>
+<title>Add comments on Files and URLs � add_comments • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -153,7 +153,7 @@ and <code>verbose_msg</code> will be <code>&#39;Your comment was successfully po
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/domain_report.html
+++ b/docs/reference/domain_report.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get Domain Report � domain_report • virustotal</title>
+<title>Get Domain Report � domain_report • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -118,8 +118,8 @@ resolutions, detected_communicating_samples, `Opera domain info`, `TrendMicro ca
 <span class='co'># </span>
 <span class='co'># # Before calling the function, set the API key using set_key('api_key_here')</span>
 <span class='co'>#    </span>
-<span class='co'># domain_report("http://www.google.com")</span>
-<span class='co'># domain_report("http://www.goodsfwrfw.com") # Domain not found</span>
+<span class='co'># domain_report("https://www.google.com")</span>
+<span class='co'># domain_report("https://www.goodsfwrfw.com") # Domain not found</span>
 <span class='co'>## ---------------------------------------------</span></div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -145,7 +145,7 @@ resolutions, detected_communicating_samples, `Opera domain info`, `TrendMicro ca
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/file_report.html
+++ b/docs/reference/file_report.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get File Scan Report � file_report • virustotal</title>
+<title>Get File Scan Report � file_report • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -140,7 +140,7 @@ scan_date, permalink, verbose_msg, total, positives, sha256, md5</code></p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -173,7 +173,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/ip_report.html
+++ b/docs/reference/ip_report.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get IP Report � ip_report • virustotal</title>
+<title>Get IP Report � ip_report • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -141,7 +141,7 @@ undetected_referrer_samples, detected_communicating_samples, resolutions, undete
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/rate_limit.html
+++ b/docs/reference/rate_limit.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Rate Limits � rate_limit • virustotal</title>
+<title>Rate Limits � rate_limit • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -103,7 +103,7 @@ that tracks number of requests per minute, and enforces appropriate waiting.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/rescan_file.html
+++ b/docs/reference/rescan_file.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Rescan already submitted files � rescan_file • virustotal</title>
+<title>Rescan already submitted files � rescan_file • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -142,7 +142,7 @@ all of which can be used to retrieve the report using <code><a href='file_report
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/scan_file.html
+++ b/docs/reference/scan_file.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Submit a file for scanning � scan_file • virustotal</title>
+<title>Submit a file for scanning � scan_file • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -139,7 +139,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/scan_url.html
+++ b/docs/reference/scan_url.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Submit URL for scanning � scan_url • virustotal</title>
+<title>Submit URL for scanning � scan_url • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -114,7 +114,7 @@ fetch the report using <code><a href='url_report.html'>url_report</a></code></p>
 <span class='co'># </span>
 <span class='co'># # Before calling the function, set the API key using set_key('api_key_here')</span>
 <span class='co'># </span>
-<span class='co'># scan_url("http://www.google.com")</span>
+<span class='co'># scan_url("https://www.google.com")</span>
 <span class='co'>## ---------------------------------------------</span></div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -140,7 +140,7 @@ fetch the report using <code><a href='url_report.html'>url_report</a></code></p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/set_key.html
+++ b/docs/reference/set_key.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Set API Key � set_key • virustotal</title>
+<title>Set API Key � set_key • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -125,7 +125,7 @@ Once you have set the API key, you can use any of the functions.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/url_report.html
+++ b/docs/reference/url_report.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Get URL Report � url_report • virustotal</title>
+<title>Get URL Report � url_report • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -119,7 +119,7 @@ When scan is set to <code>1</code>, the result includes a <code>scan_id</code> f
 <span class='co'># </span>
 <span class='co'># # Before calling the function, set the API key using set_key('api_key_here')</span>
 <span class='co'># </span>
-<span class='co'># url_report("http://www.google.com")</span>
+<span class='co'># url_report("https://www.google.com")</span>
 <span class='co'># url_report(scan_id = "ebdd15c397d2b0c6f50c3f2df531357d1201ff5976802316405e60880d6bf5ec-1478786749")</span>
 <span class='co'>## ---------------------------------------------</span></div></pre>
   </div>
@@ -146,7 +146,7 @@ When scan is set to <code>1</code>, the result includes a <code>scan_id</code> f
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/virustotal-package.html
+++ b/docs/reference/virustotal-package.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>virustotal: Access Virustotal API � virustotal-package • virustotal</title>
+<title>virustotal: Access Virustotal API � virustotal-package • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -109,7 +109,7 @@ Gaurav Sood
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/virustotal_GET.html
+++ b/docs/reference/virustotal_GET.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Base POST AND GET functions. Not exported. � virustotal_GET • virustotal</title>
+<title>Base POST AND GET functions. Not exported. � virustotal_GET • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -96,7 +96,7 @@
       <dt>key</dt>
       <dd>A character string containing Virustotal API Key. The default is retrieved from <code>Sys.getenv(&quot;VirustotalToken&quot;)</code>.</dd>
       <dt>&#8230;</dt>
-      <dd>Additional arguments passed to <code><a href='http://www.rdocumentation.org/packages/httr/topics/GET'>GET</a></code>.</dd>
+      <dd>Additional arguments passed to <code><a href='https://www.rdocumentation.org/packages/httr/topics/GET'>GET</a></code>.</dd>
     </dl>
     
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
@@ -122,7 +122,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/virustotal_POST.html
+++ b/docs/reference/virustotal_POST.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>POST � virustotal_POST • virustotal</title>
+<title>POST � virustotal_POST • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -98,7 +98,7 @@
       <dt>key</dt>
       <dd>A character string containing Virustotal API Key. The default is retrieved from <code>Sys.getenv(&quot;VirustotalToken&quot;)</code>.</dd>
       <dt>&#8230;</dt>
-      <dd>Additional arguments passed to <code><a href='http://www.rdocumentation.org/packages/httr/topics/POST'>POST</a></code>.</dd>
+      <dd>Additional arguments passed to <code><a href='https://www.rdocumentation.org/packages/httr/topics/POST'>POST</a></code>.</dd>
     </dl>
     
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
@@ -124,7 +124,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/virustotal_check.html
+++ b/docs/reference/virustotal_check.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Request Response Verification � virustotal_check • virustotal</title>
+<title>Request Response Verification � virustotal_check • virustotal</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -61,7 +61,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="http://github.com/soodoku/virustotal">
+  <a href="https://github.com/soodoku/virustotal">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -115,7 +115,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://hadley.github.io/pkgdown/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/man/domain_report.Rd
+++ b/man/domain_report.Rd
@@ -28,8 +28,8 @@ Gives category of the domain from bitdefender.
 
 # Before calling the function, set the API key using set_key('api_key_here')
    
-domain_report("http://www.google.com")
-domain_report("http://www.goodsfwrfw.com") # Domain not found
+domain_report("https://www.google.com")
+domain_report("https://www.goodsfwrfw.com") # Domain not found
 }
 }
 \references{

--- a/man/scan_url.Rd
+++ b/man/scan_url.Rd
@@ -24,7 +24,7 @@ fetch the report using \code{\link{url_report}}
 
 # Before calling the function, set the API key using set_key('api_key_here')
 
-scan_url("http://www.google.com")
+scan_url("https://www.google.com")
 }
 }
 \references{

--- a/man/url_report.Rd
+++ b/man/url_report.Rd
@@ -29,7 +29,7 @@ Retrieve a scan report for a given URL. If no scan report is available, set \cod
 
 # Before calling the function, set the API key using set_key('api_key_here')
 
-url_report("http://www.google.com")
+url_report("https://www.google.com")
 url_report(scan_id = "ebdd15c397d2b0c6f50c3f2df531357d1201ff5976802316405e60880d6bf5ec-1478786749")
 }
 }

--- a/tests/testthat/test-data-structures.R
+++ b/tests/testthat/test-data-structures.R
@@ -13,7 +13,7 @@ test_that("can decrypt secrets and data structures verified", {
 
   # Testing URL Report
   # ------------------------------
-  report <- url_report("http://www.google.com")
+  report <- url_report("https://www.google.com")
   expect_that(report, is_a("data.frame"))
 
   report <- url_report(scan_id = "ebdd15c397d2b0c6f50c3f2df531357d1201ff5976802316405e60880d6bf5ec-1478786749")
@@ -46,10 +46,10 @@ test_that("can decrypt secrets and data structures verified", {
   report <- rescan_file(hash='99017f6eebbac24f351415dd410d522d')
 	expect_that(report, is_a("data.frame"))
 
-	report <- scan_url("http://www.google.com")
+	report <- scan_url("https://www.google.com")
 	expect_that(report, is_a("data.frame"))
 
-	report <- domain_report("http://www.google.com")
+	report <- domain_report("https://www.google.com")
 	expect_that(report, is_a("list"))
 
   })

--- a/vignettes/using_virustotal.Rmd
+++ b/vignettes/using_virustotal.Rmd
@@ -38,7 +38,7 @@ set_key("your_key")
 Get report on a domain, including passive DNS:
 
 ```{r, eval=F,  domain}
-domain_report("http://www.google.com")$categories
+domain_report("https://www.google.com")$categories
 ```
 ```
 ## [[1]]
@@ -47,12 +47,12 @@ domain_report("http://www.google.com")$categories
 #### Scan URL 
 
 ```{r, eval=F, scan_url}
-scan_url("http://www.google.com")
+scan_url("https://www.google.com")
 ```
 
 ```
 ##                                                                                                             permalink               resource
-## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ http://www.google.com/
+## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ https://www.google.com/
 ```
 
 #### Get URL report
@@ -60,20 +60,20 @@ scan_url("http://www.google.com")
 Get report on a domain, including URL:
 
 ```{r, eval=F, url}
-head(url_report("http://www.google.com")[, 1:2], 10)
+head(url_report("https://www.google.com")[, 1:2], 10)
 ```
 ```
 ##                                                                        scan_id              resource
-## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
+## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
 ```
 #### Get IP report
 

--- a/vignettes/using_virustotal.html
+++ b/vignettes/using_virustotal.html
@@ -142,31 +142,31 @@ install_github(&quot;soodoku/virustotal&quot;)</code></pre>
 <div id="get-domain-report" class="section level4">
 <h4>Get domain report</h4>
 <p>Get report on a domain, including passive DNS:</p>
-<pre class="r"><code>domain_report(&quot;http://www.google.com&quot;)$categories</code></pre>
+<pre class="r"><code>domain_report(&quot;https://www.google.com&quot;)$categories</code></pre>
 <pre><code>## [[1]]
 ## [1] &quot;searchengines&quot;</code></pre>
 </div>
 <div id="scan-url" class="section level4">
 <h4>Scan URL</h4>
-<pre class="r"><code>scan_url(&quot;http://www.google.com&quot;)</code></pre>
+<pre class="r"><code>scan_url(&quot;https://www.google.com&quot;)</code></pre>
 <pre><code>##                                                                                                             permalink               resource
-## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ http://www.google.com/</code></pre>
+## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ https://www.google.com/</code></pre>
 </div>
 <div id="get-url-report" class="section level4">
 <h4>Get URL report</h4>
 <p>Get report on a domain, including URL:</p>
-<pre class="r"><code>head(url_report(&quot;http://www.google.com&quot;)[, 1:2], 10)</code></pre>
+<pre class="r"><code>head(url_report(&quot;https://www.google.com&quot;)[, 1:2], 10)</code></pre>
 <pre><code>##                                                                        scan_id              resource
-## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com</code></pre>
+## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com</code></pre>
 </div>
 <div id="get-ip-report" class="section level4">
 <h4>Get IP report</h4>

--- a/vignettes/using_virustotal.md
+++ b/vignettes/using_virustotal.md
@@ -42,7 +42,7 @@ Get report on a domain, including passive DNS:
 
 
 ```r
-domain_report("http://www.google.com")$categories
+domain_report("https://www.google.com")$categories
 ```
 ```
 ## [[1]]
@@ -52,12 +52,12 @@ domain_report("http://www.google.com")$categories
 
 
 ```r
-scan_url("http://www.google.com")
+scan_url("https://www.google.com")
 ```
 
 ```
 ##                                                                                                             permalink               resource
-## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ http://www.google.com/
+## 1 https://www.virustotal.com/url/dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf/analysis/1464817664/ https://www.google.com/
 ```
 
 #### Get URL report
@@ -66,20 +66,20 @@ Get report on a domain, including URL:
 
 
 ```r
-head(url_report("http://www.google.com")[, 1:2], 10)
+head(url_report("https://www.google.com")[, 1:2], 10)
 ```
 ```
 ##                                                                        scan_id              resource
-## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
-## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 http://www.google.com
+## 1  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 2  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 3  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 4  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 5  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 6  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 7  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 8  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 9  dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
+## 10 dd014af5ed6b38d9130e3f466f850e46d21b951199d53a18ef29ee9341614eaf-1464816996 https://www.google.com
 ```
 #### Get IP report
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://& (UnknownHostException) with 2 occurrences migrated to:  
  https://& ([https](https://&) result UnknownHostException).
* http://www.goodsfwrfw.com (UnknownHostException) with 3 occurrences migrated to:  
  https://www.goodsfwrfw.com ([https](https://www.goodsfwrfw.com) result UnknownHostException).
* http://hadley.github.io/pkgdown/ (404) with 20 occurrences migrated to:  
  https://hadley.github.io/pkgdown/ ([https](https://hadley.github.io/pkgdown/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://leafo.net with 1 occurrences migrated to:  
  https://leafo.net ([https](https://leafo.net) result 200).
* http://www.google.com with 77 occurrences migrated to:  
  https://www.google.com ([https](https://www.google.com) result 200).
* http://www.google.com/ with 5 occurrences migrated to:  
  https://www.google.com/ ([https](https://www.google.com/) result 200).
* http://www.r-pkg.org/badges/version/virustotal with 2 occurrences migrated to:  
  https://www.r-pkg.org/badges/version/virustotal ([https](https://www.r-pkg.org/badges/version/virustotal) result 200).
* http://www.virustotal.com with 7 occurrences migrated to:  
  https://www.virustotal.com ([https](https://www.virustotal.com) result 200).
* http://www.virustotal.com/ with 2 occurrences migrated to:  
  https://www.virustotal.com/ ([https](https://www.virustotal.com/) result 200).
* http://github.com/soodoku/virustotal with 22 occurrences migrated to:  
  https://github.com/soodoku/virustotal ([https](https://github.com/soodoku/virustotal) result 301).
* http://github.com/soodoku/virustotal/issues with 2 occurrences migrated to:  
  https://github.com/soodoku/virustotal/issues ([https](https://github.com/soodoku/virustotal/issues) result 301).
* http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 with 1 occurrences migrated to:  
  https://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 ([https](https://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1) result 301).
* http://www.rdocumentation.org/packages/httr/topics/GET with 1 occurrences migrated to:  
  https://www.rdocumentation.org/packages/httr/topics/GET ([https](https://www.rdocumentation.org/packages/httr/topics/GET) result 301).
* http://www.rdocumentation.org/packages/httr/topics/POST with 1 occurrences migrated to:  
  https://www.rdocumentation.org/packages/httr/topics/POST ([https](https://www.rdocumentation.org/packages/httr/topics/POST) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1999/xhtml with 1 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences